### PR TITLE
Fix mispaced quote in Youtube video embed

### DIFF
--- a/static/src/interface/About.js
+++ b/static/src/interface/About.js
@@ -56,7 +56,7 @@ export default class About {
 		const video = document.createElement('div')
 		video.id = 'video'
 		//vid YT0k99hCY5I 
-		video.innerHTML = `<iframe id='youtube-iframe' src="https://www.youtube.com/embed/eKeI63VSpto`?modestbranding=0&showinfo=0&enablejsapi=1" frameborder="0" allowfullscreen></iframe>`
+		video.innerHTML = `<iframe id='youtube-iframe' src="https://www.youtube.com/embed/eKeI63VSpto?modestbranding=0&showinfo=0&enablejsapi=1" frameborder="0" allowfullscreen></iframe>`
 		content.appendChild(video)
 
 		this._ytplayer = null


### PR DESCRIPTION
`webpack -p` gives the following error-

```
ERROR in ./src/interface/About.js
Module build failed: SyntaxError: Invalid left-hand side in assignment expression (59:112)
```

There is an errant ` in the URL right before the ? that is closing the quote too early. 